### PR TITLE
Add Support for Going to First/Last Chart

### DIFF
--- a/appl/smry_appl.cpp
+++ b/appl/smry_appl.cpp
@@ -2567,6 +2567,25 @@ void SmryAppl::keyPressEvent ( QKeyEvent *event )
             this->update_chart_labels();
         }
     }
+
+    else if (m_smry_loaded && (event->key() == Qt::Key_Home)) {
+        // User pressed 'Home'.  Go to first chart in series.
+        chart_ind = 0;
+
+        stackedWidget->setCurrentIndex(chart_ind);
+
+        this->update_chart_labels();
+    }
+
+    else if (m_smry_loaded && (event->key() == Qt::Key_End)) {
+        // User pressed 'End'.  Go to last chart in series.
+        chart_ind = static_cast<int>(chartList.size()) - 1;
+
+        stackedWidget->setCurrentIndex(chart_ind);
+
+        this->update_chart_labels();
+    }
+
     else if ( m_smry_loaded && event->key() == Qt::Key_F  &&  m_ctrl_key  && !m_shift_key && !m_alt_key ){
 
         this->export_figure("/project/multiscale/users/tskille/prog/test_data/tjohei.png", 0);

--- a/appl/smry_appl.cpp
+++ b/appl/smry_appl.cpp
@@ -1949,6 +1949,18 @@ bool SmryAppl::eventFilter ( QObject *object, QEvent *event )
 
             return true;
 
+        } else if (m_smry_loaded && (keyEvent->key() == Qt::Key_Home)) {
+            // User pressed 'Home'.  Go to first chart in series.
+            this->select_first_chart();
+
+            return true;
+
+        } else if (m_smry_loaded && (keyEvent->key() == Qt::Key_End)) {
+            // User pressed 'End'.  Go to last chart in series.
+            this->select_last_chart();
+
+            return true;
+
         } else if ( keyEvent->key()  == Qt::Key_Z  &&  m_ctrl_key  && !m_shift_key && !m_alt_key ) {
 
             auto min_max_range = axisX[chart_ind]->get_xrange();
@@ -2570,20 +2582,12 @@ void SmryAppl::keyPressEvent ( QKeyEvent *event )
 
     else if (m_smry_loaded && (event->key() == Qt::Key_Home)) {
         // User pressed 'Home'.  Go to first chart in series.
-        chart_ind = 0;
-
-        stackedWidget->setCurrentIndex(chart_ind);
-
-        this->update_chart_labels();
+        this->select_first_chart();
     }
 
     else if (m_smry_loaded && (event->key() == Qt::Key_End)) {
         // User pressed 'End'.  Go to last chart in series.
-        chart_ind = static_cast<int>(chartList.size()) - 1;
-
-        stackedWidget->setCurrentIndex(chart_ind);
-
-        this->update_chart_labels();
+        this->select_last_chart();
     }
 
     else if ( m_smry_loaded && event->key() == Qt::Key_F  &&  m_ctrl_key  && !m_shift_key && !m_alt_key ){
@@ -2964,4 +2968,20 @@ void SmryAppl::update_full_xrange(int chart_index)
     }
 
     axisX[chart_index]->set_full_range(min_x, max_x);
+}
+
+void SmryAppl::select_first_chart()
+{
+    this->chart_ind = 0;
+    this->stackedWidget->setCurrentIndex(this->chart_ind);
+
+    this->update_chart_labels();
+}
+
+void SmryAppl::select_last_chart()
+{
+    this->chart_ind = static_cast<int>(this->chartList.size()) - 1;
+    stackedWidget->setCurrentIndex(this->chart_ind);
+
+    this->update_chart_labels();
 }

--- a/appl/smry_appl.hpp
+++ b/appl/smry_appl.hpp
@@ -242,6 +242,8 @@ private:
 
     void update_full_xrange(int chart_index);
 
+    void select_first_chart();
+    void select_last_chart();
 };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -96,6 +96,8 @@ static void printHelp()
     std::cout << " <ctrl> + <delete>   delete active chart  \n";
     std::cout << " <page down>   next chart, create new if last chart already active  \n";
     std::cout << " <page down>   previous chart  \n";
+    std::cout << " <home>   first chart  \n";
+    std::cout << " <end>   last chart  \n";
     std::cout << " <down>  previous summary vector or previous command  \n";
     std::cout << " <up>  next summary vector or next command  \n";
     std::cout << "\n\n";


### PR DESCRIPTION
This commit activates key press events for the 'Home' and 'End' keys, at least while not in command mode, to go to the first and last chart respectively.

No unit test at the moment.