### PR TITLE
Recognise a Few More Miscellaneous Vector Types

### DIFF
--- a/appl/smry_appl.cpp
+++ b/appl/smry_appl.cpp
@@ -922,9 +922,15 @@ SmryAppl::vectorEntry SmryAppl::make_vector_entry ( std::string vect_name )
 {
     SmryAppl::vectorEntry res;
 
-    std::vector<std::string> misc = {"TCPU", "ELAPSED", "TIME", "TIMESTEP", "YEARS", "DAY", "MAXDPR",
-        "MAXDSG", "MAXDSO", "MAXDSW", "MLINEARS", "MONTH", "MSUMLINS", "NEWTON", "NLINEARS", "STEPTYPE",
-        "YEAR", "MSUMNEWT" };
+    const std::vector<std::string> misc {
+        "DAY",
+        "ELAPSED",
+        "MAXDPR", "MAXDSG", "MAXDSO", "MAXDSW", "MLINEARS", "MONTH", "MSUMLINS", "MSUMNEWT",
+        "NEWTON", "NLINEARS", "NLINSMAX", "NLINSMIN",
+        "STEPTYPE",
+        "TCPU", "TCPUDAY", "TCPUTS", "TELAPLIN", "TIME", "TIMESTEP",
+        "YEAR", "YEARS",
+    };
 
     if ( std::find ( misc.begin(), misc.end(), vect_name ) != misc.end() ) {
         res = std::make_tuple ( vect_name, "", "" );


### PR DESCRIPTION
In particular, add vectors such as `NLINSMAX`, `NLINSMIN`, `TCPUDAY` and `TCPUTS` to the list of `misc` vectors.  We're most likely to see these when plotting "all" vectors&ndash;through the `-a` command line option&ndash;from a result set that uses the `PERFORMA` summary keyword.